### PR TITLE
Correct effect.cpp

### DIFF
--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1081,7 +1081,7 @@ double effect::get_percentage( const std::string &arg, int val, bool reduced ) c
 
     double ret = 0;
     // If both bot values are zero the formula is one_in(top), else the formula is x_in_y(top, bot)
-    if( bot_base != 0 && bot_scale != 0 ) {
+    if( bot_base != 0 || bot_scale != 0 ) {
         if( bot_base + bot_scale == 0 ) {
             // Special crash avoidance case, in most effect fields 0 = "nothing happens"
             // so assume false here for consistency


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfix "Make x_chance_bot work right"

#### Purpose of change

Fixes #45435 (at least partially)

effect.cpp was treating both base and scale for `chance_bot` as 0 if either of them were.

#### Describe the solution

Change the logic to match what the comment above it says it should be.

#### Describe alternatives you've considered

If this doesn't work, will need to go more deeply into what's happening.

#### Testing

Creating test cases for these is a future goal; @Venera3, if you could check it for now?

#### Additional context

Reminded about bug by #46795.